### PR TITLE
#39 並べ替え機能のドラッグエリアを拡張する

### DIFF
--- a/app/shopping-list/[id]/category-management.tsx
+++ b/app/shopping-list/[id]/category-management.tsx
@@ -194,7 +194,11 @@ function CategoryItem({
       <div className="flex items-center justify-between gap-x-2 p-2">
         <div className="flex items-center gap-x-2">
           <div className="bg-neutral-100 p-1">
-            <GripVertical {...listeners} size={18} className="cursor-grab text-neutral-400" />
+            <GripVertical
+              {...listeners}
+              size={18}
+              className="cursor-grab touch-none text-neutral-400"
+            />
           </div>
           <div className="text-md">{name}</div>
         </div>


### PR DESCRIPTION
スマホ時に画面スクロールと競合してドラッグがしにくくなっていたため、ドラッグエリアに`touch-none`を追加してドラッグをしやすくする変更を加えた